### PR TITLE
MMPU Compatibility

### DIFF
--- a/pmpro-email-confirmation.php
+++ b/pmpro-email-confirmation.php
@@ -203,6 +203,7 @@ add_filter( "pmpro_has_membership_access_filter", "pmproec_pmpro_has_membership_
  * Reference: https://www.paidmembershipspro.com/hook/pmpro_has_membership_level/
  */
 function pmproec_pmpro_has_membership_level( $haslevel, $user_id, $levels ) {
+	global $pmpro_pages;
 
 	//if they don't have the level, ignore this
 	if ( ! $haslevel ) {
@@ -211,6 +212,11 @@ function pmproec_pmpro_has_membership_level( $haslevel, $user_id, $levels ) {
 		
 	//if not checking for a level, ignore this
 	if ( empty( $levels ) ) {
+		return $haslevel;
+	}
+
+	// If the user is trying to cancel, let them.
+	if ( is_page( $pmpro_pages['cancel'] ) ) {
 		return $haslevel;
 	}
 	


### PR DESCRIPTION
Builds off of #45 which should be merged first.

Specific MMPU compatibility fixes are:
- Showing link to resend email confirmation on account page when any of user's levels needs confirmation
- Avoiding edge cases when modifying non-member text
- Updating "reset confirmation on email change" feature to check if any level is set to reset confirmation