### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-email-confirmation.php
+++ b/pmpro-email-confirmation.php
@@ -315,7 +315,8 @@ add_action("init", "pmproec_init_validate");
 function pmproec_pmpro_confirmation_message($message)
 {
 	//must be an email confirmation level
-	if(!empty($_REQUEST['level']) && pmproec_isEmailConfirmationLevel(intval($_REQUEST['level'])))
+	$level = pmpro_getLevelAtCheckout();
+	if ( ! empty( $level->id ) && pmproec_isEmailConfirmationLevel( intval( $level->id ) ) )
 	{
 		global $current_user;
 		if($current_user->pmpro_email_confirmation_key != "validated")

--- a/pmpro-email-confirmation.php
+++ b/pmpro-email-confirmation.php
@@ -203,6 +203,7 @@ add_filter( "pmpro_has_membership_access_filter", "pmproec_pmpro_has_membership_
  * Reference: https://www.paidmembershipspro.com/hook/pmpro_has_membership_level/
  */
 function pmproec_pmpro_has_membership_level( $haslevel, $user_id, $levels ) {
+	global $pmpro_pages;
 
 	//if they don't have the level, ignore this
 	if ( ! $haslevel ) {
@@ -211,6 +212,11 @@ function pmproec_pmpro_has_membership_level( $haslevel, $user_id, $levels ) {
 		
 	//if not checking for a level, ignore this
 	if ( empty( $levels ) ) {
+		return $haslevel;
+	}
+
+	// If the user is trying to cancel, let them.
+	if ( is_page( $pmpro_pages['cancel'] ) ) {
 		return $haslevel;
 	}
 	


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.