### PR TITLE
Updating headings for a11y

### DIFF
--- a/pmpro-email-confirmation.php
+++ b/pmpro-email-confirmation.php
@@ -42,7 +42,7 @@ function pmproec_pmpro_membership_level_after_other_settings() {
 	}
 
 ?>
-<h3 class="topborder"><?php esc_html_e( 'Email Confirmation', 'pmpro-email-confirmation' ); ?></h3>
+<h2 class="topborder"><?php esc_html_e( 'Email Confirmation', 'pmpro-email-confirmation' ); ?></h2>
 <table>
 <tbody class="form-table">
 	<tr>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.